### PR TITLE
Generate interface{} for openapi's Any

### DIFF
--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -25,23 +25,19 @@ import (
 )
 
 // N5StartsWithNumber defines model for 5StartsWithNumber.
-type N5StartsWithNumber struct {
-}
+type N5StartsWithNumber map[string]interface{}
 
 // AnyType1 defines model for AnyType1.
-type AnyType1 struct {
-}
+type AnyType1 interface{}
 
 // AnyType2 defines model for AnyType2.
-type AnyType2 struct {
-}
+type AnyType2 interface{}
 
 // CustomStringType defines model for CustomStringType.
 type CustomStringType string
 
 // GenericObject defines model for GenericObject.
-type GenericObject struct {
-}
+type GenericObject map[string]interface{}
 
 // NullableProperties defines model for NullableProperties.
 type NullableProperties struct {

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -657,8 +657,8 @@ func GenerateTypesFromSchemaRef(schemaref *openapi3.SchemaRef, name string) ([]T
 					tds = append(tds, additionalAndChildrenTypes[1:]...)
 				}
 			}
+			tds[0].Schema.GoType = GenStructFromSchema(tds[0].Schema)
 		}
-		tds[0].Schema.GoType = GenStructFromSchema(tds[0].Schema)
 		return tds, nil
 	} else {
 		f := schema.Format


### PR DESCRIPTION
如果 schema 没有 `Properties` 应当被认为是 Any 类型，应该走 595 行的逻辑即止而不是再去生成空结构体